### PR TITLE
fix(competence): inline prototype-pollution guards so CodeQL recogniz…

### DIFF
--- a/packages/competence/CHANGELOG.md
+++ b/packages/competence/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This document contains the list of changes made to the competence package. The format is based on the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
+## Version 3.13.2
+
+Follow-up to 3.13.1: CodeQL did not recognize the shared `assertSafeFieldPath()` call as a sanitizer (it is interprocedural), so the two `js/prototype-pollution-utility` alerts stayed open (CA-91).
+
+* fix(competence): add inline `__proto__`/`constructor`/`prototype` literal guards inside `#setFieldByPath` and `#getFieldByPath`, adjacent to each property access/write, so static analysis recognizes the barrier at the sink; `assertSafeFieldPath()` is retained as the early-rejection policy check and its unit tests are unchanged — runtime behavior is identical (unsafe paths are still rejected with 422)
+* build(release): bump package version from `3.13.1` to `3.13.2`
+
 ## Version 3.13.1
 
 Security hardening for the prototype-pollution CodeQL findings raised after the scanner was modernized in CA-90 (CA-91).

--- a/packages/competence/bin/competence-web-application.js
+++ b/packages/competence/bin/competence-web-application.js
@@ -3758,6 +3758,11 @@ class CompetenceWebApplication extends TiWebAppManager {
         const parts = path.split( "." );
         let current = obj;
         for ( const part of parts ) {
+            // Inline literal guard (mirrors assertSafeFieldPath above) so static analysis recognizes the barrier
+            // adjacent to the property access (CWE-1321 / CodeQL js/prototype-pollution-utility).
+            if ( part === "__proto__" || part === "constructor" || part === "prototype" ) {
+                throw exceptions.raise( exceptions.exceptionCode.E_WEB_INVALID_REQUEST_PARAMETERS, { details: `Unsafe field path segment '${ part }'.` }, exceptions.httpCode.C_422 );
+            }
             if ( current === null || current === undefined ) return undefined;
             current = current[ part ];
         }
@@ -3778,12 +3783,21 @@ class CompetenceWebApplication extends TiWebAppManager {
         const parts = path.split( "." );
         let current = obj;
         for ( let i = 0; i < parts.length - 1; i++ ) {
-            if ( current[ parts[ i ] ] === undefined || current[ parts[ i ] ] === null ) {
-                current[ parts[ i ] ] = {};
+            const key = parts[ i ];
+            // Inline literal guard (mirrors assertSafeFieldPath above) so static analysis recognizes the barrier
+            // adjacent to each property write (CWE-1321 / CodeQL js/prototype-pollution-utility).
+            if ( key === "__proto__" || key === "constructor" || key === "prototype" ) {
+                throw exceptions.raise( exceptions.exceptionCode.E_WEB_INVALID_REQUEST_PARAMETERS, { details: `Unsafe field path segment '${ key }'.` }, exceptions.httpCode.C_422 );
             }
-            current = current[ parts[ i ] ];
+            if ( current[ key ] === undefined || current[ key ] === null ) {
+                current[ key ] = {};
+            }
+            current = current[ key ];
         }
         const lastPart = parts[ parts.length - 1 ];
+        if ( lastPart === "__proto__" || lastPart === "constructor" || lastPart === "prototype" ) {
+            throw exceptions.raise( exceptions.exceptionCode.E_WEB_INVALID_REQUEST_PARAMETERS, { details: `Unsafe field path segment '${ lastPart }'.` }, exceptions.httpCode.C_422 );
+        }
         if ( value === null || value === undefined || value === "" ) {
             // For specialization specifically, store null. For optional scalars (email, birthDate), delete the key.
             if ( path === "career.specialization" ) {

--- a/packages/competence/package.json
+++ b/packages/competence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ti-engine/competence",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "The ti-engine is an open source, free to use—both for personal and commercial projects—framework for the creation of microservice-based solutions using node.js.",
   "author": "Boris Kostadinov <kostadinov.boris@gmail.com>",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
…es the barrier (CA-91)

Follow-up to 3.13.1. CodeQL did not recognize the shared assertSafeFieldPath() call as a sanitizer (it is interprocedural), so the two js/prototype-pollution-utility alerts (#3/#4) stayed open after the previous fix merged. Add inline __proto__/constructor/prototype literal guards adjacent to each property access and write in #setFieldByPath and #getFieldByPath so static analysis sees the barrier at the sink; assertSafeFieldPath() is retained as the tested early-rejection policy. Runtime behavior is unchanged (unsafe paths still rejected with 422); suite 356/356 green.

Bump to 3.13.2.