### PR TITLE
build(competence): add Codespaces devcontainer for test/demo runs (CA…

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -21,10 +21,10 @@ from the dev compose), so no Azure/OIDC setup is needed.
 Useful terminal commands inside the Codespace:
 
 ```bash
-docker compose logs -f competence   # app logs
-docker compose ps                    # status/health
-docker compose restart competence    # restart after a change
-docker compose down                  # stop the stack
+docker compose logs -f competence        # app logs
+docker compose ps                         # status/health
+docker compose up -d --build competence   # rebuild + restart after a code change
+docker compose down                       # stop the stack
 ```
 
 ## What to set up in GitHub
@@ -35,8 +35,13 @@ repo** an owner may need to configure it:
 - **Enable Codespaces for the org** — Org **Settings ▸ Codespaces**: allow the repo/members and set a
   **spending limit / billing** (Codespaces compute is billed beyond the free quota).
 - **Port sharing (only if you want to share a demo link)** — forwarded ports are **private** by
-  default. In the **Ports** panel, set port 3000 visibility to **Public** or **Org**. Org policy can
-  restrict public forwarding (Org Settings ▸ Codespaces ▸ *port visibility*).
+  default. In the **Ports** panel you can set port 3000 to **Org** (signed-in members of your
+  organization only) or **Public** (**anyone on the internet with the URL**). Org policy can restrict
+  public forwarding (Org Settings ▸ Codespaces ▸ *port visibility*).
+
+  > ⚠️ **Disposable test data only.** This stack runs with **test/local authentication** and
+  > **dev-only fallback secrets** (see the intro). Never put real or sensitive data in it, and only
+  > make port 3000 **Public** for a short-lived demo — a Public URL is reachable by anyone who has it.
 - **Machine type (optional)** — the 2-core default works; pick 4-core when creating the Codespace for
   a faster build.
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,48 @@
+# Running competence in GitHub Codespaces (test / demo only)
+
+This `.devcontainer/` lets you run the **competence** app straight from GitHub, in the browser, for
+**testing and demos** — not production. It starts the repo's dev `docker-compose.yml` (the app +
+Redis Stack) inside a Codespace and forwards the app on port **3000**. Sign-in uses **local auth**
+plus the dev **Test User** panel (`TI_WEB_AUTH_METHODS=local`, `COMPETENCE_TEST_USER_ENABLED=true`
+from the dev compose), so no Azure/OIDC setup is needed.
+
+> Production hosting is different — deploy the published image (`ghcr.io/belleal/ti-engine-competence`)
+> to a container platform. See [`packages/competence/INSTALL.md`](../packages/competence/INSTALL.md).
+
+## Launch it
+
+1. On GitHub, open the repo and switch to a branch that contains this `.devcontainer/` (e.g. `current`,
+   or `master` once merged).
+2. **Code ▸ Codespaces ▸ Create codespace on `<branch>`**.
+3. Wait for the first build (a few minutes — it builds the app image and pulls Redis Stack).
+4. When the **Ports** panel shows port **3000**, open its URL. Sign in via the Test User pills or
+   `admin` / `admin`.
+
+Useful terminal commands inside the Codespace:
+
+```bash
+docker compose logs -f competence   # app logs
+docker compose ps                    # status/health
+docker compose restart competence    # restart after a change
+docker compose down                  # stop the stack
+```
+
+## What to set up in GitHub
+
+For personal repos, Codespaces is on by default (with a monthly free quota). For an **organization
+repo** an owner may need to configure it:
+
+- **Enable Codespaces for the org** — Org **Settings ▸ Codespaces**: allow the repo/members and set a
+  **spending limit / billing** (Codespaces compute is billed beyond the free quota).
+- **Port sharing (only if you want to share a demo link)** — forwarded ports are **private** by
+  default. In the **Ports** panel, set port 3000 visibility to **Public** or **Org**. Org policy can
+  restrict public forwarding (Org Settings ▸ Codespaces ▸ *port visibility*).
+- **Machine type (optional)** — the 2-core default works; pick 4-core when creating the Codespace for
+  a faster build.
+
+Nothing else is required for testing:
+
+- **No registry auth** — the Codespace **builds** the image from source; it does not pull from GHCR.
+- **No secrets** — the dev compose supplies throwaway dev values for the message-hash and cookie
+  secrets. (You *may* add Codespaces secrets under repo/org settings if you later want to test with
+  real OIDC, but it's not needed for local-auth testing.)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,11 @@
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
 
-    // Forward the competence web port. Codespaces gives it a PRIVATE URL by default; set it to
-    // Public/Org in the Ports panel to share a demo link (subject to your org's Codespaces policy).
+    // Forward the competence web port. Codespaces gives it a PRIVATE URL by default. In the Ports
+    // panel you can share it as "Org" (signed-in members of your organization only) or "Public"
+    // (ANYONE on the internet with the URL). This stack uses test-only auth + dev-only fallback
+    // secrets, so only expose a Public URL for a throwaway demo with disposable data — never real
+    // data (subject to your org's Codespaces policy).
     "forwardPorts": [ 3000 ],
     "portsAttributes": {
         "3000": {
@@ -26,7 +29,9 @@
 
     // Build + start the stack on every Codespace start (idempotent; only rebuilds on change).
     // First run takes a few minutes while the image builds and Redis Stack is pulled.
-    "postStartCommand": "docker compose up -d --build",
+    // The docker-in-docker daemon starts asynchronously, so wait (bounded to 90s) for it to be
+    // ready before invoking compose — otherwise the first run can hit "cannot connect to the Docker daemon".
+    "postStartCommand": "timeout 90 sh -c 'until docker info >/dev/null 2>&1; do echo waiting for docker daemon...; sleep 2; done' && docker compose up -d --build",
 
     // One-time hint printed in the terminal after the Codespace attaches.
     "postAttachCommand": "echo 'competence is starting on port 3000 — open the forwarded 3000 URL from the Ports panel. Sign in with the Test User panel or admin/admin. Logs: docker compose logs -f competence | Stop: docker compose down'"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// GitHub Codespaces / Dev Containers configuration for TESTING & DEMO of the competence app.
+// NOT for production. It brings up the repo's dev docker-compose stack (competence + Redis Stack)
+// inside the Codespace and forwards the app on port 3000. Auth uses the dev compose settings
+// (TI_WEB_AUTH_METHODS=local + the test-user panel), so you can sign in without configuring Azure.
+{
+    "name": "competence (test/demo)",
+
+    // A lightweight Ubuntu workspace. The app itself runs as a container via docker compose (below),
+    // not in this container — so a crash/restart of the app never tears down your Codespace.
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+    // Provides the Docker engine + the `docker compose` CLI inside the Codespace.
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+
+    // Forward the competence web port. Codespaces gives it a PRIVATE URL by default; set it to
+    // Public/Org in the Ports panel to share a demo link (subject to your org's Codespaces policy).
+    "forwardPorts": [ 3000 ],
+    "portsAttributes": {
+        "3000": {
+            "label": "competence app",
+            "onAutoForward": "notify"
+        }
+    },
+
+    // Build + start the stack on every Codespace start (idempotent; only rebuilds on change).
+    // First run takes a few minutes while the image builds and Redis Stack is pulled.
+    "postStartCommand": "docker compose up -d --build",
+
+    // One-time hint printed in the terminal after the Codespace attaches.
+    "postAttachCommand": "echo 'competence is starting on port 3000 — open the forwarded 3000 URL from the Ports panel. Sign in with the Test User panel or admin/admin. Logs: docker compose logs -f competence | Stop: docker compose down'"
+}


### PR DESCRIPTION
…-90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Codespaces setup instructions for testing and demos.
  * Documented local authentication, the Test User panel, forwarded port access, and common Docker Compose commands.

* **New Features**
  * Added a Dev Container configuration that automatically starts the app and Redis Stack.
  * Configured port 3000 forwarding and workspace startup guidance for a smoother setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->