### PR TITLE
Cloud Run first-run walkthrough + move the GitHub Actions to Node 24 (CA-94)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,17 +14,17 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOY_SA }}
@@ -32,7 +32,7 @@ jobs:
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
       - name: Derive image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/belleal/ti-engine-competence
@@ -43,7 +43,7 @@ jobs:
             type=match,pattern=competence-v(.*),group=1
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/competence-v') }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: packages/competence/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
       # No npm cache: it keys off package-lock.json, which is gitignored in this repo.
@@ -31,11 +31,11 @@ jobs:
     needs: lint-and-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: packages/competence/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           node-version: 22
       # No npm cache: it keys off package-lock.json, which is gitignored in this repo.
+      # setup-node's automatic cache also stays off by itself, because it only activates when
+      # package.json declares `packageManager` / `devEngines.packageManager` and none of ours do.
+      # Adding such a field would silently switch caching on here — pass
+      # `package-manager-cache: false` if that ever happens.
       - name: Install dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,14 +22,14 @@ jobs:
         language: [ 'javascript-typescript' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,8 +14,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-node@main
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Prepare Environment - Install
@@ -32,8 +32,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-node@main
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,10 +14,16 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # These jobs run npm lifecycle scripts and hold a publish token, so they give up
+      # anything they do not need: the checkout credential (nothing here pushes) and
+      # setup-node's automatic dependency cache.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Prepare Environment - Install
         run: npm install
       - name: Prepare Environment - CI
@@ -33,9 +39,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - name: Prepare Environment - Install
         run: npm install

--- a/docs/superpowers/plans/2026-07-29-competence-gcp-scale-to-zero.md
+++ b/docs/superpowers/plans/2026-07-29-competence-gcp-scale-to-zero.md
@@ -669,10 +669,13 @@ cat <<EOF
 
 ==> DONE. Manual steps that cannot be scripted (spec §7.4):
 
-  1. Create the app's OAuth client (Console → APIs & Services → Credentials →
-     Create credentials → OAuth client ID → Web application). Consent screen
-     must be INTERNAL. Leave the redirect URI empty for now — deploy.sh prints
-     the exact value to add once the service URL exists.
+  1. Create the app's OAuth client (Console → Google Auth Platform → Clients →
+     Create client → Web application). Set the Audience to INTERNAL, which keeps
+     sign-in to your Workspace domain and needs no verification. INTERNAL is only
+     offered when the project belongs to an organization; without one you get
+     EXTERNAL and must add each tester as an allowed test user. Leave the redirect
+     URI empty for now — deploy.sh prints the exact value to add once the service
+     URL exists.
 
   2. Store its client secret (the value is read from stdin, never echoed):
        gcloud secrets create competence-google-client-secret \\

--- a/packages/competence/INSTALL.md
+++ b/packages/competence/INSTALL.md
@@ -3,7 +3,7 @@
 **Audience:** system administrators deploying the **competence** HR appraisal application.
 **Scope:** installing, configuring, running, upgrading, and troubleshooting the app as a container. Application usage (running appraisal cycles, etc.) is out of scope.
 
-> **Package versions this guide targets:** competence `3.13.3`, `@ti-engine/web-framework` `1.16.0`, `@ti-engine/core` `1.7.1`. Container image: `ghcr.io/belleal/ti-engine-competence`.
+> **Package versions this guide targets:** competence `3.16.0`, `@ti-engine/web-framework` `1.18.1`, `@ti-engine/core` `1.7.1`. Container image: `ghcr.io/belleal/ti-engine-competence`.
 
 ---
 
@@ -55,11 +55,11 @@ There are no other required services. (The framework can call peer ti-engine ser
 
 - **Name:** `ghcr.io/belleal/ti-engine-competence`
 - **Tags:**
-  - `:X.Y.Z` — a released version (e.g. `:3.13.3`), published from a `competence-v*` git tag. **Use a pinned version tag in production.**
+  - `:X.Y.Z` — a released version (e.g. `:3.16.0`), published from a `competence-v*` git tag. **Use a pinned version tag in production.**
   - `:latest` — the most recent released version.
   - `:edge` — the tip of `master` (pre-release; for staging only).
 - **Base:** `node:22-alpine`, non-root (`node` user), `NODE_ENV=production`.
-- **Pulling:** if the package is public, `docker pull ghcr.io/belleal/ti-engine-competence:3.13.3`. If private, authenticate to GHCR first:
+- **Pulling:** if the package is public, `docker pull ghcr.io/belleal/ti-engine-competence:3.16.0`. If private, authenticate to GHCR first:
   ```bash
   echo "$GITHUB_TOKEN" | docker login ghcr.io -u <your-username> --password-stdin
   ```
@@ -216,7 +216,7 @@ services:
     restart: unless-stopped
 
   competence:
-    image: ghcr.io/belleal/ti-engine-competence:3.13.3
+    image: ghcr.io/belleal/ti-engine-competence:3.16.0
     depends_on:
       redis:
         condition: service_healthy
@@ -263,7 +263,7 @@ docker run -d --name competence \
   -e COMPETENCE_TEST_USER_ENABLED=false \
   -e TI_MESSAGE_EXCHANGE_SECURITY_HASH_KEY=<strong-random> \
   -e TI_WEB_COOKIE_SECRET=<strong-random> \
-  ghcr.io/belleal/ti-engine-competence:3.13.3
+  ghcr.io/belleal/ti-engine-competence:3.16.0
 ```
 
 ### Method C — Kubernetes (pointers)

--- a/packages/competence/INSTALL.md
+++ b/packages/competence/INSTALL.md
@@ -278,8 +278,15 @@ docker run -d --name competence \
 A hosted environment that costs approximately nothing when idle: one Cloud Run
 service holding the app plus a `redis:8-alpine` sidecar, with Redis snapshotting
 to a mounted Cloud Storage bucket so data survives scale-to-zero. Fronted by
-Identity-Aware Proxy with an email allowlist. Scripts live in
-[`deploy/gcp/`](deploy/gcp/README.md); run them in Cloud Shell:
+Identity-Aware Proxy with an email allowlist.
+
+> **First-time setup:** follow [`deploy/gcp/WALKTHROUGH.md`](deploy/gcp/WALKTHROUGH.md),
+> a guided nine-phase run through both the Google Cloud and GitHub sides. It covers the
+> ordering that must be respected (Google Cloud before GitHub), the two steps that fail
+> by design on a first deploy, and the post-deploy checks. The summary below is the
+> reference form.
+
+Scripts live in [`deploy/gcp/`](deploy/gcp/README.md); run them in Cloud Shell:
 
 ```bash
 cd packages/competence/deploy/gcp

--- a/packages/competence/deploy/gcp/README.md
+++ b/packages/competence/deploy/gcp/README.md
@@ -4,6 +4,11 @@ Two scripts and one manifest. Nothing runs, and nothing is billed, while nobody
 is testing; data survives idle periods because Redis snapshots onto a Cloud
 Storage bucket.
 
+**Setting this up for the first time?** Follow **[WALKTHROUGH.md](WALKTHROUGH.md)** —
+a guided, nine-phase run through both the Google Cloud and GitHub sides, including
+the ordering that trips people up and the two steps that fail by design on a first
+deploy. The rest of this file is the short reference.
+
 | File | Purpose |
 |---|---|
 | `bootstrap.sh` | One-time, idempotent project setup. Re-runnable. `DRY_RUN=1` previews it. |
@@ -31,8 +36,9 @@ inputs change.
 `GCP_DEPLOY_SA`) must already be set, or the CD workflow's publish job fails —
 see the CD precondition in **[INSTALL.md](../../INSTALL.md), Method D**.
 
-Full walkthrough, cost model, and the recovery procedure for a locked-out
-sign-in: **[INSTALL.md](../../INSTALL.md), Method D**.
+Guided first-time setup: **[WALKTHROUGH.md](WALKTHROUGH.md)**. Cost model and the
+recovery procedure for a locked-out sign-in: **[INSTALL.md](../../INSTALL.md),
+Method D**.
 
 Design rationale: `docs/superpowers/specs/2026-07-29-competence-gcp-scale-to-zero-design.md`.
 

--- a/packages/competence/deploy/gcp/README.md
+++ b/packages/competence/deploy/gcp/README.md
@@ -1,8 +1,9 @@
 # competence on Google Cloud Run — scale-to-zero test environment
 
-Two scripts and one manifest. Nothing runs, and nothing is billed, while nobody
-is testing; data survives idle periods because Redis snapshots onto a Cloud
-Storage bucket.
+Two scripts and one manifest. While nobody is testing, no Cloud Run instance runs
+and no compute is billed — only the stored image, the Redis snapshot and the
+secrets persist, for a few cents a month. Data survives idle periods because Redis
+snapshots onto a Cloud Storage bucket.
 
 **Setting this up for the first time?** Follow **[WALKTHROUGH.md](WALKTHROUGH.md)** —
 a guided, nine-phase run through both the Google Cloud and GitHub sides, including

--- a/packages/competence/deploy/gcp/WALKTHROUGH.md
+++ b/packages/competence/deploy/gcp/WALKTHROUGH.md
@@ -1,0 +1,364 @@
+# Deploying competence to Google Cloud Run — first-time walkthrough
+
+A step-by-step setup guide for a **scale-to-zero test environment**: nothing runs, and nothing is
+billed, while nobody is testing. Every step says *which* surface you should be on — **Cloud Shell**,
+**GCP Console**, **GitHub**, or a **browser** — because the usual way to lose an hour here is doing
+the right thing in the wrong place.
+
+| | |
+|---|---|
+| **Region** | `europe-west1` |
+| **Hands-on time** | roughly 60–90 minutes |
+| **Expected cost** | €0–1 / month |
+| **You need** | Owner on the GCP project, admin on the GitHub repository |
+
+For the operational reference (full variable list, TLS, upgrades, backups) see
+[INSTALL.md](../../INSTALL.md) — this file is the guided first run. For *why* each piece is shaped the
+way it is, see `docs/superpowers/specs/2026-07-29-competence-gcp-scale-to-zero-design.md`.
+
+## What you will end up with
+
+- One Cloud Run service holding **two containers** — the app and a `redis:8-alpine` sidecar reached
+  over `127.0.0.1` — that scales to zero when idle.
+- Redis writing its snapshot to a Cloud Storage bucket, so data outlives the idle shutdown.
+- A normal HTTPS link fronted by **Identity-Aware Proxy**: only the colleagues you name get through.
+
+---
+
+## Before you start: the ordering that matters
+
+**Google Cloud has to exist before GitHub can talk to it.** The release pipeline pushes the image
+into an Artifact Registry repository and signs in through a Workload Identity provider, and
+`bootstrap.sh` is what creates both. So until you have run bootstrap *and* set the three repository
+variables, every CD run fails at its Google Cloud authentication step with:
+
+```text
+google-github-actions/auth failed with: the GitHub Action workflow must
+specify exactly one of "workload_identity_provider" or "credentials_json"
+```
+
+That failure happens **before** the build, so such a run publishes no image anywhere — not even to
+GHCR, where it would otherwise land. It is not a broken pipeline; it is the pipeline telling you the
+Google Cloud side is not ready yet. Work through the phases in order and it goes green.
+
+Two more things that look like faults but are not:
+
+- **`deploy.sh` fails on its last step the first time.** Its final action asserts IAP, and IAP must be
+  switched on in the Console once before the CLI can touch it. Everything before that step succeeded.
+- **The OAuth redirect URI cannot be registered in advance**, because it contains the service URL,
+  which does not exist until after the first deploy. Phase 7 loops back to fill it in.
+
+---
+
+## Phase 1 — Pick the project and confirm billing
+
+**Where: GCP Console**
+
+- [ ] Open [console.cloud.google.com](https://console.cloud.google.com/) and use the project picker
+      to create a project (e.g. `competence-test`) or select an existing one.
+- [ ] **Write down the project *ID*, not the display name.** It is the lowercase-with-digits string
+      such as `competence-test-431807`, shown under *Project info*. Everything below calls it
+      `<PROJECT_ID>`.
+- [ ] Under **Billing**, confirm a billing account is linked. Cloud Run and Artifact Registry refuse
+      to work without one even when your usage sits inside the free tier.
+
+A dedicated project is worth it: it keeps this environment's cost, permissions and audit trail
+separate, and teardown becomes "delete the project".
+
+## Phase 2 — Run the bootstrap script
+
+**Where: Cloud Shell**
+
+Cloud Shell is a Linux terminal in the browser with `gcloud`, `docker`, `git` and `openssl` already
+installed and already signed in as you. Nothing to install locally.
+
+- [ ] In the Console top bar, click the terminal icon (**Activate Cloud Shell**) and wait for a prompt.
+- [ ] Point it at your project:
+      ```bash
+      gcloud config set project <PROJECT_ID>
+      ```
+- [ ] Clone the repository and enter the deploy directory:
+      ```bash
+      git clone https://github.com/Belleal/ti-engine.git
+      cd ti-engine/packages/competence/deploy/gcp
+      ```
+- [ ] **Preview first.** This prints every command the script would run and executes none of them:
+      ```bash
+      DRY_RUN=1 ./bootstrap.sh
+      ```
+- [ ] Run it for real:
+      ```bash
+      ./bootstrap.sh
+      ```
+
+What it creates:
+
+| Resource | Why |
+|---|---|
+| Enabled APIs | Cloud Run, Artifact Registry, Secret Manager, Storage, IAP, IAM Credentials, STS, Billing Budgets |
+| Artifact Registry repo `competence` | Where the image lives — Cloud Run can only pull from here |
+| Mirrored `redis:8-alpine` | The sidecar image; Cloud Run cannot pull from Docker Hub |
+| Bucket `<PROJECT_ID>-competence-redis` | Holds the Redis snapshot. Versioned, noncurrent versions expire after 7 days |
+| Service account `competence-run` | What the app runs as: read on three secrets, write on that one bucket, nothing else |
+| Two generated secrets | Cookie secret and message-integrity key, created by `openssl` and piped straight into Secret Manager — never printed |
+| Workload Identity pool + provider | Lets GitHub Actions sign in with no stored key, and only from `master` or a `competence-v*` tag |
+| Budget alert | €5/month. Skipped with instructions if you lack billing-admin rights, which is fine |
+
+**Keep the output.** The script ends with a `NEXT STEPS` block containing the three GitHub variable
+values needed in phase 4. Re-running the script prints it again, so nothing is lost — it is safe to
+re-run, because every step checks for existing state first.
+
+## Phase 3 — Create the app's Google sign-in client
+
+**Where: GCP Console, then Cloud Shell**
+
+This is the sign-in *the app itself* shows, separate from the IAP gate in phase 7. You will sign in
+twice, which is normal and usually one click the second time.
+
+> The script's output says *APIs & Services → Credentials*. Google has since moved this under
+> **Google Auth Platform**, with *Branding*, *Audience* and *Clients* sections. If your menu differs,
+> search the Console for "Google Auth Platform".
+
+- [ ] Open **Google Auth Platform**. If prompted to configure the app, fill in *Branding* — an app
+      name and support email are enough.
+- [ ] Under **Audience**, choose **Internal**. That restricts sign-in to your Workspace domain and
+      avoids Google's verification process. (Internal is only offered when the project belongs to an
+      organization; otherwise you get *External* and must add each tester as a test user.)
+- [ ] **Clients → Create client**, type **Web application**, name it e.g. `competence app sign-in`.
+      **Leave the redirect URI empty** — phase 7 fills it in.
+- [ ] Copy both values. The **Client ID** ends in `.apps.googleusercontent.com` and is not sensitive.
+      The **Client secret** is — do not put it in a file, a chat, or a commit.
+- [ ] Store the secret. This reads from your keyboard, so nothing lands in shell history:
+      ```bash
+      gcloud secrets create competence-google-client-secret \
+        --data-file=- --replication-policy=user-managed --locations=europe-west1 \
+        --project <PROJECT_ID>
+      ```
+      Paste the secret, press **Enter**, then **Ctrl-D**.
+- [ ] Re-run `./bootstrap.sh` so the runtime service account is granted read access to it. It will
+      report what already exists and add only the missing binding.
+
+## Phase 4 — Give GitHub the three variables
+
+**Where: GitHub**
+
+- [ ] Repository → **Settings** → **Secrets and variables** → **Actions**.
+- [ ] Select the **Variables** tab (*not* Secrets) → **New repository variable**, three times:
+
+| Name | Value |
+|---|---|
+| `GCP_PROJECT_ID` | your project ID |
+| `GCP_WIF_PROVIDER` | `projects/<number>/locations/global/workloadIdentityPools/github/providers/github-oidc` |
+| `GCP_DEPLOY_SA` | `competence-deploy@<PROJECT_ID>.iam.gserviceaccount.com` |
+
+None of the three is sensitive — they are identifiers, and the security comes from the provider
+trusting only this repository on `master` or a `competence-v*` tag.
+
+## Phase 5 — Get the image into Artifact Registry
+
+**Where: GitHub, then Cloud Shell**
+
+Pick either route. The tag gives you a pinned version to point at deliberately; the re-run is quicker.
+
+**Option A — re-run the pipeline.** Repository → **Actions** → the most recent failed **CD** run →
+**Re-run failed jobs**. It rebuilds from the same commit, which is what you want.
+
+**Option B — cut a release tag**, from a local clone on `master`:
+
+```bash
+git checkout master && git pull
+git tag competence-v3.16.0
+git push origin competence-v3.16.0
+```
+
+That publishes `:3.16.0` and `:latest` alongside `:edge`, to both registries from a single build.
+
+- [ ] Watch the run go green, then confirm the image arrived:
+      ```bash
+      gcloud artifacts docker images list \
+        europe-west1-docker.pkg.dev/<PROJECT_ID>/competence --include-tags
+      ```
+      You should see `ti-engine-competence` and the mirrored `redis`. Note the tag you want to deploy.
+
+## Phase 6 — Deploy the service
+
+**Where: Cloud Shell**
+
+- [ ] Optional preview:
+      ```bash
+      DRY_RUN=1 GOOGLE_CLIENT_ID=<client-id> ./deploy.sh
+      ```
+- [ ] Deploy. `ADMIN_EMAILS` is your own Google address — without it the admin configuration screens
+      stay unreachable, because the allowlist is empty:
+      ```bash
+      GOOGLE_CLIENT_ID=<client-id> \
+      ADMIN_EMAILS=you@yourdomain.com \
+      IMAGE_TAG=edge \
+      ./deploy.sh
+      ```
+
+> **The last step will fail on a first deploy, and that is expected.** IAP has to be enabled in the
+> Console once before the CLI can assert it. Everything before that step succeeded; phase 7 enables
+> IAP and you re-run the script, after which it succeeds every time.
+
+- [ ] Copy the two things it prints: the **service URL** and the **redirect URI** to register.
+
+Behind the scenes it rendered the manifest, applied it, asserted that unauthenticated access is
+refused, then patched the two settings that could not be known until the URL existed — the trusted
+origin and the OAuth callback.
+
+## Phase 7 — Close the gate, then let testers in
+
+**Where: GCP Console, then Cloud Shell**
+
+> **Do not share the URL before finishing this phase.** This environment runs with the developer
+> test-user picker enabled, which lets anyone who reaches the login screen act as *any* employee,
+> Supervisor included. IAP is the only thing preventing that.
+
+- [ ] **Register the redirect URI.** Google Auth Platform → **Clients** → your client → under
+      *Authorised redirect URIs*, add the exact value `deploy.sh` printed:
+      ```text
+      https://competence-<number>.europe-west1.run.app/login/google-callback
+      ```
+      Sign-in fails with a redirect-mismatch error until this matches character for character.
+- [ ] **Enable IAP.** Cloud Run → `competence` → **Security** tab → **Require authentication** →
+      **Identity-Aware Proxy**. Accept the prompt granting IAP permission to invoke the service.
+- [ ] **Add your testers** — same Security tab, or the IAP page — each as a principal with the role
+      **IAP-secured Web App User**. The CLI equivalent, one per person:
+      ```bash
+      gcloud run services add-iam-policy-binding competence \
+        --region europe-west1 --project <PROJECT_ID> \
+        --member="user:colleague@yourdomain.com" \
+        --role="roles/iap.httpsResourceAccessor"
+      ```
+      Add yourself too, or you will lock yourself out.
+- [ ] Re-run the deploy so its final IAP assertion passes and the script finishes clean.
+- [ ] **Prove the gate is on** before sharing anything. The first command must show
+      `iap-enabled: 'true'`; the second must **not** list `allUsers`:
+      ```bash
+      gcloud run services describe competence --region europe-west1 \
+        --project <PROJECT_ID> --format='yaml(metadata.annotations)'
+
+      gcloud run services get-iam-policy competence --region europe-west1 \
+        --project <PROJECT_ID>
+      ```
+
+## Phase 8 — Seed the demo data and sign in
+
+**Where: Cloud Shell, then a browser**
+
+- [ ] Turn the seed on:
+      ```bash
+      gcloud run services update competence --region europe-west1 \
+        --project <PROJECT_ID> --update-env-vars COMPETENCE_PRELOAD_DATA=true
+      ```
+- [ ] Open the service URL. Expect **5–15 seconds** for the first load — that is the cold start, and
+      it recurs after each idle period. Sign in with Google (IAP), then again on the app's own login
+      screen.
+- [ ] On the login screen pick an identity from the **Test user** panel — `#22` holds all three roles
+      and is the best starting point — and confirm the dashboard renders with demo data.
+- [ ] **Turn the seed back off.** While it stays on, the seed is re-applied on every boot and will
+      resurrect records a tester deleted:
+      ```bash
+      gcloud run services update competence --region europe-west1 \
+        --project <PROJECT_ID> --update-env-vars COMPETENCE_PRELOAD_DATA=false
+      ```
+
+## Phase 9 — The one test that actually matters
+
+**Where: browser, then Cloud Shell**
+
+Everything else here has been exercised. The Redis-snapshot-to-bucket path has not — it is reasoned
+from documented behaviour, never run against a live deployment (design §9.1). Until this passes, do
+not trust the environment with anything a tester would be annoyed to lose.
+
+- [ ] In the app, create something recognisable — a cycle, or an evaluation. Note the time.
+- [ ] Leave it alone for **~20 minutes** so Cloud Run shuts the instance down. Do not reload.
+- [ ] Reload, sign in, and confirm what you created is still there.
+- [ ] Confirm the snapshot was written — the timestamp must be **later** than your change:
+      ```bash
+      gcloud storage ls -l gs://<PROJECT_ID>-competence-redis/dump.rdb
+      ```
+
+**If the data is gone or `dump.rdb` is missing, stop.** That is the documented fallback trigger:
+Redis moves to an Always-Free `e2-micro` VM reached over a private address, which needs **no
+application change** — only a different `TI_MEMORY_CACHE_REDIS_HOST`. Note that the durability margin
+is thinner than it first appears: under CPU throttling the periodic save is opportunistic, so the
+shutdown save is effectively the only reliable one, and it has about ten seconds to serialise, upload
+and rename.
+
+Worth checking once more:
+
+- A colleague *without* the IAP role is refused; one with it gets in.
+- Admin screens open for the address in `ADMIN_EMAILS`, and not for another tester.
+- A few days later: Billing → Reports shows roughly nothing, and the €5 budget alert exists.
+
+---
+
+## Living with it
+
+### Shipping a new version
+
+A merge to `master` publishes the image automatically, but **it does not reach the running service**.
+Re-run the deploy to pick it up:
+
+```bash
+cd ~/ti-engine && git pull
+cd packages/competence/deploy/gcp
+GOOGLE_CLIENT_ID=<client-id> ADMIN_EMAILS=you@yourdomain.com IMAGE_TAG=edge ./deploy.sh
+```
+
+Redeploy while the service is **idle**. A deploy briefly creates two revisions, and if someone is
+actively using the app the draining instance can overwrite the snapshot with a staler one (CA-96).
+
+### Locked out of the app
+
+If the OAuth client breaks nobody can sign in, because local credentials are disabled. Re-enable them
+briefly — the `^:^` prefix changes the list separator so the comma stays part of the value, and
+`--project` keeps you off the wrong service:
+
+```bash
+gcloud run services update competence --region europe-west1 \
+  --project <PROJECT_ID> \
+  --update-env-vars ^:^TI_WEB_AUTH_METHODS=local,openid-google
+```
+
+That enables a hardcoded `admin`/`admin` login, safe only because IAP still fronts the service.
+**Revert the moment sign-in works again:**
+
+```bash
+gcloud run services update competence --region europe-west1 \
+  --project <PROJECT_ID> \
+  --update-env-vars TI_WEB_AUTH_METHODS=openid-google
+```
+
+### Tearing it down
+
+Deleting the project removes everything including billing. To keep the project, delete the Cloud Run
+service, the bucket, the Artifact Registry repository and the three secrets.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| Pipeline: `must specify exactly one of workload_identity_provider` | The three repository variables are missing or misspelled (phase 4). Check you used the *Variables* tab, not Secrets. |
+| Pipeline: `Security Token Service API has not been used` | Bootstrap has not run. Run `./bootstrap.sh`. |
+| Pipeline: permission denied pushing the image | The Artifact Registry repository does not exist yet — bootstrap creates it. Phase 2 before phase 5. |
+| `deploy.sh`: unsubstituted placeholders remain | A guard doing its job; the manifest and script disagree. Re-clone rather than hand-editing. |
+| `deploy.sh`: the final `--iap` step fails | Expected on a first deploy. Enable IAP in the Console, then re-run (phase 7). |
+| Sign-in: `redirect_uri_mismatch` | The callback is not registered on the OAuth client, or does not match exactly (phase 7). |
+| "No sign-in method is configured" | The client ID never reached the service. Re-run `deploy.sh` with `GOOGLE_CLIENT_ID` set. |
+| A Google error before the app appears at all | IAP refusing you. Your account needs *IAP-secured Web App User* (phase 7). |
+| Admin screens missing for you | `ADMIN_EMAILS` was empty or a different address. Re-run `deploy.sh` with it set. |
+| First page load takes ages | Cold start, 5–15 seconds, by design — the service was scaled to zero and cost nothing while idle. |
+| Writes start failing under heavy use | Redis hit its memory ceiling and refuses writes rather than silently dropping them. Check the logs; raise the sidecar's `--maxmemory` if this is real usage. |
+
+**Where to look:** Cloud Run → `competence` → **Logs** shows both containers. A healthy boot shows
+Redis connecting, then `Web server started at address 'http://0.0.0.0:8080'`, then
+`Instance '…' started successfully`.
+
+---
+
+Only **synthetic seed data** belongs in this environment. No real employee records.

--- a/packages/competence/deploy/gcp/WALKTHROUGH.md
+++ b/packages/competence/deploy/gcp/WALKTHROUGH.md
@@ -1,7 +1,9 @@
 # Deploying competence to Google Cloud Run — first-time walkthrough
 
-A step-by-step setup guide for a **scale-to-zero test environment**: nothing runs, and nothing is
-billed, while nobody is testing. Every step says *which* surface you should be on — **Cloud Shell**,
+A step-by-step setup guide for a **scale-to-zero test environment**: while nobody is testing, no
+Cloud Run instance runs and no compute is billed. A few resources do persist — the stored container
+image, the Redis snapshot and three secrets — which is where the €0–1/month below comes from.
+Every step says *which* surface you should be on — **Cloud Shell**,
 **GCP Console**, **GitHub**, or a **browser** — because the usual way to lose an hour here is doing
 the right thing in the wrong place.
 
@@ -163,15 +165,18 @@ Pick either route. The tag gives you a pinned version to point at deliberately; 
 **Option A — re-run the pipeline.** Repository → **Actions** → the most recent failed **CD** run →
 **Re-run failed jobs**. It rebuilds from the same commit, which is what you want.
 
-**Option B — cut a release tag**, from a local clone on `master`:
+**Option B — cut a release tag**, from a local clone on `master`. Derive the version from the package
+rather than typing one, so the tag always matches what the image will report:
 
 ```bash
 git checkout master && git pull
-git tag competence-v3.16.0
-git push origin competence-v3.16.0
+VERSION=$(node -p "require('./packages/competence/package.json').version")
+git tag "competence-v${VERSION}"
+git push origin "competence-v${VERSION}"
 ```
 
-That publishes `:3.16.0` and `:latest` alongside `:edge`, to both registries from a single build.
+That publishes `:<version>` and `:latest` alongside `:edge`, to both registries from a single build.
+Tag only a version whose changelog entry is in place — the tag is what the release is named after.
 
 - [ ] Watch the run go green, then confirm the image arrived:
       ```bash

--- a/packages/competence/deploy/gcp/bootstrap.sh
+++ b/packages/competence/deploy/gcp/bootstrap.sh
@@ -280,10 +280,13 @@ cat <<EOF
 
 ==> DONE. Manual steps that cannot be scripted (spec §7.4):
 
-  1. Create the app's OAuth client (Console → APIs & Services → Credentials →
-     Create credentials → OAuth client ID → Web application). Consent screen
-     must be INTERNAL. Leave the redirect URI empty for now — deploy.sh prints
-     the exact value to add once the service URL exists.
+  1. Create the app's OAuth client (Console → Google Auth Platform → Clients →
+     Create client → Web application). Set the Audience to INTERNAL, which keeps
+     sign-in to your Workspace domain and needs no verification. INTERNAL is only
+     offered when the project belongs to an organization; without one you get
+     EXTERNAL and must add each tester as an allowed test user. Leave the redirect
+     URI empty for now — deploy.sh prints the exact value to add once the service
+     URL exists.
 
   2. Store its client secret (the value is read from stdin, never echoed):
        gcloud secrets create competence-google-client-secret \\

--- a/packages/competence/test/helpers/in-memory-cache.js
+++ b/packages/competence/test/helpers/in-memory-cache.js
@@ -54,6 +54,7 @@ function resolvePath( root, path ) {
     let cursor = root;
     for ( let i = 0; i < parts.length; i++ ) {
         const part = parts[ i ];
+        if ( part === "__proto__" || part === "constructor" || part === "prototype" ) return undefined;
         // Wildcard segment (e.g. `*.<evaluationID>`): search every value of the current object for the remaining
         // path and return the first match — matching Redis-JSON `$.*.<key>` semantics as used by fetchEvaluation.
         if ( part === "*" ) {
@@ -124,6 +125,9 @@ class InMemoryCache {
         const parent = parentPath.length ? resolvePath( this.storage[ key ], parentPath ) : this.storage[ key ];
         if ( !parent || typeof parent !== "object" ) {
             return Promise.reject( new Error( `in-memory-cache setJSON: parent path does not exist for key "${ key }" (path ${ JSON.stringify( path ) })` ) );
+        }
+        if ( parent === Object.prototype || parent === Function.prototype ) {
+            return Promise.reject( new Error( `in-memory-cache setJSON: unsafe parent object for key "${ key }" (path ${ JSON.stringify( path ) })` ) );
         }
         const leafExists = Object.prototype.hasOwnProperty.call( parent, leaf );
         if ( ( overrideMode === 1 && leafExists ) || ( overrideMode === 2 && !leafExists ) ) {


### PR DESCRIPTION
Two independent changes, one commit each.

## 1. A guided walkthrough for the Cloud Run deployment — `8c9118c`

`INSTALL.md` Method D is operator reference: correct, but the wrong shape for a first run. This adds [`deploy/gcp/WALKTHROUGH.md`](packages/competence/deploy/gcp/WALKTHROUGH.md) — nine phases, each step labelled with the surface it happens on (Cloud Shell / GCP Console / GitHub / browser), because the common way to lose an hour here is doing the right thing in the wrong window.

It leads with the ordering constraint that is otherwise learned the hard way: **Google Cloud has to exist before GitHub can talk to it.** `bootstrap.sh` creates both the Artifact Registry repository the pipeline pushes into and the Workload Identity provider it signs in through, so until it has run and the three repository variables are set, every CD run fails at its auth step — *before* the build, publishing nothing at all. It also flags the two steps that fail **by design** on a first run: `deploy.sh`'s closing IAP assertion (IAP must be enabled in the Console once first) and the OAuth redirect URI, which cannot be registered until the service URL exists.

Every command and identifier in it was cross-checked against `bootstrap.sh`, `deploy.sh` and `service.yaml` rather than transcribed from the design doc. Linked from Method D and the deploy README so it is reachable from either entry point.

## 2. Every GitHub Action moved to its Node 24 major — `dfe34b8`

GitHub reports *"Node 20 is being deprecated. This workflow is running with Node 24 by default"* on our runs. Nothing is broken — the runner already forces Node 24 — but every action we reference still declares `node20` and is riding a compatibility shim.

It was not just the action named in the log. **All nine distinct actions across the four workflows declared `node20`.** Each target major was verified to declare `node24` before bumping:

| Action | | Action | |
|---|---|---|---|
| `actions/checkout` | v4 → v7 | `docker/metadata-action` | v5 → v6 |
| `actions/setup-node` | v4 → v7 | `docker/build-push-action` | v6 → v7 |
| `docker/setup-buildx-action` | v3 → v4 | `google-github-actions/auth` | v2 → v3 |
| `docker/login-action` | v3 → v4 | `github/codeql-action` | v3 → v4 |

**The more significant find:** `npm-publish.yml` referenced `actions/checkout@main` and `actions/setup-node@main` — a moving upstream *development branch* — in a job that holds `secrets.NPM_TOKEN`. Any commit landing on those branches would have executed with a publish token available. Both are now pinned like everywhere else. That matters more than the deprecation notice that prompted the change.

`auth@v3.0.0` is titled "Bump to Node 24 and remove old parameters", so its input list was checked: `workload_identity_provider` and `service_account` — the two we pass — both survive.

### What this PR can and cannot prove

Our usage is minimal (`checkout` takes no inputs at all; `setup-node` only a version), so breaking-change exposure is small. CI and CodeQL exercise **six of the nine** here. The three that only run on a `master` push — `login-action`, `metadata-action`, `auth` — cannot be validated before merge. If one misbehaves the publish job fails loudly and reverting one line fixes it.

No root version bump or changelog entry: the root changelog records npm dependency and engine changes, and the CA-90 precedent added whole workflow files without bumping it. Happy to add one if you'd rather these be recorded there.

### Still open from #101, unchanged

Pinning actions to immutable commit SHAs (`zizmor`'s blanket policy) is a separate question from this bump and remains open. If you want it, it is worth doing repo-wide together with Dependabot to keep the pins fresh — pinned-and-stale is its own hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guided nine-phase walkthrough for first-time Google Cloud Run deployment.
  * Documented setup sequencing, authentication, deployment, snapshot verification, troubleshooting, teardown, and recovery procedures.
  * Updated installation and deployment guidance to reference the new walkthrough.

* **Chores**
  * Updated CI, deployment, security analysis, and package publishing workflows to use newer action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->