### PR TITLE
feat(competence): let bootstrap.sh defer to a budget you already own …

### DIFF
--- a/docs/superpowers/plans/2026-07-29-competence-gcp-scale-to-zero.md
+++ b/docs/superpowers/plans/2026-07-29-competence-gcp-scale-to-zero.md
@@ -413,6 +413,12 @@ WIF_POOL="${WIF_POOL:-github}"
 WIF_PROVIDER="${WIF_PROVIDER:-github-oidc}"
 REDIS_IMAGE="${REDIS_IMAGE:-redis:8-alpine}"
 BUDGET_AMOUNT="${BUDGET_AMOUNT:-5EUR}"
+# Set SKIP_BUDGET=1 if you already manage a budget for this project yourself, or point
+# BUDGET_NAME at its display name so the existence check below recognises it. Without
+# one of those, a differently-named existing budget is not matched and a second one is
+# created, which means duplicate alerts on the same project.
+BUDGET_NAME="${BUDGET_NAME:-competence-test}"
+SKIP_BUDGET="${SKIP_BUDGET:-}"
 
 if [[ -n "${DRY_RUN}" ]]; then
     PROJECT_ID="${PROJECT_ID:-dry-run-project}"
@@ -640,19 +646,21 @@ BILLING_ACCOUNT=""
 if [[ -z "${DRY_RUN}" ]]; then
     BILLING_ACCOUNT="$( gcloud billing projects describe "${PROJECT_ID}" --format='value(billingAccountName)' 2>/dev/null || true )"
 fi
-if [[ -n "${DRY_RUN}" ]]; then
-    printf '    [dry-run] gcloud billing budgets create --billing-account=<account> --display-name=competence-test --budget-amount=%s --threshold-rule=percent=0.5 --threshold-rule=percent=0.9 --threshold-rule=percent=1.0 --filter-projects=projects/%s\n' "${BUDGET_AMOUNT}" "${PROJECT_NUMBER}"
+if [[ -n "${SKIP_BUDGET}" ]]; then
+    echo "    SKIPPED by request (SKIP_BUDGET is set) — you are managing the budget yourself."
+elif [[ -n "${DRY_RUN}" ]]; then
+    printf '    [dry-run] gcloud billing budgets create --billing-account=<account> --display-name=%s --budget-amount=%s --threshold-rule=percent=0.5 --threshold-rule=percent=0.9 --threshold-rule=percent=1.0 --filter-projects=projects/%s\n' "${BUDGET_NAME}" "${BUDGET_AMOUNT}" "${PROJECT_NUMBER}"
 elif [[ -z "${BILLING_ACCOUNT}" ]]; then
     echo "    SKIPPED: could not read the billing account (needs billing permissions)."
     echo "    Create it by hand: Console → Billing → Budgets & alerts → Create budget (${BUDGET_AMOUNT}/month)."
 else
-    EXISTING_BUDGET="$( gcloud billing budgets list --billing-account="${BILLING_ACCOUNT##*/}" --filter="displayName=competence-test" --format='value(name)' 2>/dev/null || true )"
+    EXISTING_BUDGET="$( gcloud billing budgets list --billing-account="${BILLING_ACCOUNT##*/}" --filter="displayName=${BUDGET_NAME}" --format='value(name)' 2>/dev/null || true )"
     if [[ -n "${EXISTING_BUDGET}" ]]; then
-        echo "    budget competence-test already exists — left untouched"
+        echo "    budget ${BUDGET_NAME} already exists — left untouched"
     else
         gcloud billing budgets create \
             --billing-account="${BILLING_ACCOUNT##*/}" \
-            --display-name="competence-test" \
+            --display-name="${BUDGET_NAME}" \
             --budget-amount="${BUDGET_AMOUNT}" \
             --threshold-rule=percent=0.5 \
             --threshold-rule=percent=0.9 \

--- a/packages/competence/deploy/gcp/WALKTHROUGH.md
+++ b/packages/competence/deploy/gcp/WALKTHROUGH.md
@@ -110,6 +110,18 @@ What it creates:
 values needed in phase 4. Re-running the script prints it again, so nothing is lost — it is safe to
 re-run, because every step checks for existing state first.
 
+**Already have a budget for this project?** The existence check matches on the display name
+`competence-test`, so a budget of your own with a different name is not recognised and you would end
+up with two budgets alerting on the same project. Either skip the step or point it at yours:
+
+```bash
+SKIP_BUDGET=1 ./bootstrap.sh                         # you manage the budget yourself
+BUDGET_NAME="<your budget's display name>" ./bootstrap.sh   # recognise the existing one
+```
+
+To see what yours is called: `gcloud billing budgets list --billing-account=<account-id>
+--format="table(displayName,amount.specifiedAmount)"`.
+
 ## Phase 3 — Create the app's Google sign-in client
 
 **Where: GCP Console, then Cloud Shell**
@@ -139,6 +151,26 @@ twice, which is normal and usually one click the second time.
       Paste the secret, press **Enter**, then **Ctrl-D**.
 - [ ] Re-run `./bootstrap.sh` so the runtime service account is granted read access to it. It will
       report what already exists and add only the missing binding.
+
+### Reusing an OAuth client you already have
+
+The script never creates the client, so reuse means skipping the first bullet above — but **not** the
+secret one. Three things still apply:
+
+- **Store its secret under the expected name.** `service.yaml` mounts
+  `competence-google-client-secret`, so the existing client's secret has to go into Secret Manager
+  under exactly that name. Retrieve it from Google Auth Platform → **Clients** → your client; if the
+  value is no longer displayable, add an additional secret to that client rather than creating a new
+  client.
+- **Add the redirect URI, do not replace it.** A client can hold several authorised redirect URIs, so
+  append the one `deploy.sh` prints in phase 7 and leave any existing entries alone.
+- **Know what you are sharing.** A client reused across deployments shares one consent screen and one
+  secret: rotating the secret for one deployment breaks the other. If the client lives in a different
+  GCP project that is fine — Google validates the client, not the project — but its branding and
+  Audience belong to that other project.
+
+Pass the existing client's ID as `GOOGLE_CLIENT_ID` in phase 6, and IAP is unaffected either way: it
+provisions its own OAuth client when you enable it in phase 7.
 
 ## Phase 4 — Give GitHub the three variables
 

--- a/packages/competence/deploy/gcp/bootstrap.sh
+++ b/packages/competence/deploy/gcp/bootstrap.sh
@@ -24,6 +24,12 @@ WIF_POOL="${WIF_POOL:-github}"
 WIF_PROVIDER="${WIF_PROVIDER:-github-oidc}"
 REDIS_IMAGE="${REDIS_IMAGE:-redis:8-alpine}"
 BUDGET_AMOUNT="${BUDGET_AMOUNT:-5EUR}"
+# Set SKIP_BUDGET=1 if you already manage a budget for this project yourself, or point
+# BUDGET_NAME at its display name so the existence check below recognises it. Without
+# one of those, a differently-named existing budget is not matched and a second one is
+# created, which means duplicate alerts on the same project.
+BUDGET_NAME="${BUDGET_NAME:-competence-test}"
+SKIP_BUDGET="${SKIP_BUDGET:-}"
 
 if [[ -n "${DRY_RUN}" ]]; then
     PROJECT_ID="${PROJECT_ID:-dry-run-project}"
@@ -251,19 +257,21 @@ BILLING_ACCOUNT=""
 if [[ -z "${DRY_RUN}" ]]; then
     BILLING_ACCOUNT="$( gcloud billing projects describe "${PROJECT_ID}" --format='value(billingAccountName)' 2>/dev/null || true )"
 fi
-if [[ -n "${DRY_RUN}" ]]; then
-    printf '    [dry-run] gcloud billing budgets create --billing-account=<account> --display-name=competence-test --budget-amount=%s --threshold-rule=percent=0.5 --threshold-rule=percent=0.9 --threshold-rule=percent=1.0 --filter-projects=projects/%s\n' "${BUDGET_AMOUNT}" "${PROJECT_NUMBER}"
+if [[ -n "${SKIP_BUDGET}" ]]; then
+    echo "    SKIPPED by request (SKIP_BUDGET is set) — you are managing the budget yourself."
+elif [[ -n "${DRY_RUN}" ]]; then
+    printf '    [dry-run] gcloud billing budgets create --billing-account=<account> --display-name=%s --budget-amount=%s --threshold-rule=percent=0.5 --threshold-rule=percent=0.9 --threshold-rule=percent=1.0 --filter-projects=projects/%s\n' "${BUDGET_NAME}" "${BUDGET_AMOUNT}" "${PROJECT_NUMBER}"
 elif [[ -z "${BILLING_ACCOUNT}" ]]; then
     echo "    SKIPPED: could not read the billing account (needs billing permissions)."
     echo "    Create it by hand: Console → Billing → Budgets & alerts → Create budget (${BUDGET_AMOUNT}/month)."
 else
-    EXISTING_BUDGET="$( gcloud billing budgets list --billing-account="${BILLING_ACCOUNT##*/}" --filter="displayName=competence-test" --format='value(name)' 2>/dev/null || true )"
+    EXISTING_BUDGET="$( gcloud billing budgets list --billing-account="${BILLING_ACCOUNT##*/}" --filter="displayName=${BUDGET_NAME}" --format='value(name)' 2>/dev/null || true )"
     if [[ -n "${EXISTING_BUDGET}" ]]; then
-        echo "    budget competence-test already exists — left untouched"
+        echo "    budget ${BUDGET_NAME} already exists — left untouched"
     else
         gcloud billing budgets create \
             --billing-account="${BILLING_ACCOUNT##*/}" \
-            --display-name="competence-test" \
+            --display-name="${BUDGET_NAME}" \
             --budget-amount="${BUDGET_AMOUNT}" \
             --threshold-rule=percent=0.5 \
             --threshold-rule=percent=0.9 \


### PR DESCRIPTION
…(CA-94)

Hit during a real first run: the budget existence check matched only the display name `competence-test`, so an operator who already keeps a budget on the project under their own name would not be recognised and would end up with a second budget alerting on the same project. The script should not insist on owning the budget.

Two escape hatches, neither of which changes the default path:

  SKIP_BUDGET=1   skip the step entirely — you manage the budget yourself
  BUDGET_NAME=…   point the existence check at your budget's display name

Also documents reusing an OAuth client that already exists, which the scripts support but nothing said out loud: the client is never created by bootstrap.sh, so reuse means skipping that instruction — but *not* the secret one, because service.yaml mounts `competence-google-client-secret` by name regardless of where the client came from. Plus the two things easy to get wrong when reusing: append the new redirect URI rather than replacing the existing ones, and know that a shared client means a shared secret, so rotating it for one deployment breaks the other.

* feat(competence): add `SKIP_BUDGET` and `BUDGET_NAME` to bootstrap.sh
* docs(competence): document both the existing-budget and existing-OAuth-client paths in the walkthrough